### PR TITLE
Agregando el StartPreview.

### DIFF
--- a/src/android/nl/xservices/plugins/Flashlight.java
+++ b/src/android/nl/xservices/plugins/Flashlight.java
@@ -48,6 +48,7 @@ public class Flashlight extends CordovaPlugin {
     if (isCapable()) {
       mParameters.setFlashMode(switchOn ? Camera.Parameters.FLASH_MODE_TORCH : Camera.Parameters.FLASH_MODE_OFF);
       mCamera.setParameters(mParameters);
+      mCamera.startPreview();
       callbackContext.success();
     } else {
       callbackContext.error("Device is not capable of using the flashlight. Please test with flashlight.available()");


### PR DESCRIPTION
Hice pruebas con este plugin en Phonegap 3.1 pero no me funcionó, luego de revisar la documentación de varios sitios vi que era necesario invocar al método startPreview() del objeto Camera para que se encienda el FlashLight, esto lo probé solamente en dos dispositivos, Samsung Galaxy s2 y Samsung Galaxy s3 mini. 

Cualquier información que se requiera al respecto estoy a la orden para contribuir,
Saludos.
