### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Otherwise, the camera may be locked so it can't be used by other apps:
 ```javascript
 document.addEventListener("backbutton", function() {
   // pass exitApp as callbacks to the switchOff method
-  window.plugins.flashlight.switchOff(exitApp, exitApp);
+  window.plugins.flashlight.switchOff(exitApp(), exitApp());
 }, false);
 
 function exitApp() {


### PR DESCRIPTION
:119 -> window.plugins.flashlight.switchOff(exitApp, exitApp);
exitApp does not exist, exitApp() is the function to be called.
