### PR TITLE
Adding code to support availability detection on Android 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by [Eddy Verbruggen](http://www.x-services.nl) for iOS, Android and WP8 (since v
 
 This plugin allows you to switch the flashlight / torch of the device on and off.
 
-* Works on Android, but likely not on 2.x devices.
+* Works on Android 2.x and newer.
 * Works on iOS 5.0+, maybe even lower.
 * Works on Windows Phone 8 since v2.0.0.
 * Depends on capabilities of the device, so you can test it with an API call.

--- a/src/android/nl/xservices/plugins/Flashlight.java
+++ b/src/android/nl/xservices/plugins/Flashlight.java
@@ -8,6 +8,13 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
 import org.json.JSONException;
+import android.app.Activity;
+import android.content.pm.*;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
+
 
 public class Flashlight extends CordovaPlugin {
 
@@ -59,9 +66,14 @@ public class Flashlight extends CordovaPlugin {
   }
 
   private boolean isCapable() {
-    return mCamera != null &&
-        mCamera.getParameters().getSupportedFlashModes() != null &&
-        mCamera.getParameters().getSupportedFlashModes().contains(Camera.Parameters.FLASH_MODE_TORCH);
+    final PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+    final FeatureInfo[] featureList = packageManager.getSystemAvailableFeatures();
+    for (FeatureInfo f : featureList) {
+        if(f.name.equals(PackageManager.FEATURE_CAMERA_FLASH)){
+          return true;
+        }
+    }
+    return false;
   }
 
   private void toggleTorch(boolean switchOn, CallbackContext callbackContext) {


### PR DESCRIPTION
This commit makes Android 2.x behave correctly when retrieving the availability of a torch on the device. 
Newer Android versions work as well.
