### PR TITLE
Check mCamera is not null before trying to access methods

### DIFF
--- a/src/android/nl/xservices/plugins/Flashlight.java
+++ b/src/android/nl/xservices/plugins/Flashlight.java
@@ -87,9 +87,11 @@ public class Flashlight extends CordovaPlugin {
     // we need to release the camera, so other apps can use it
     new Thread(new Runnable() {
       public void run() {
-        mCamera.setPreviewCallback(null);
-        mCamera.stopPreview();
-        mCamera.release();
+	if (mCamera != null) {
+          mCamera.setPreviewCallback(null);
+          mCamera.stopPreview();
+          mCamera.release();
+        }
         releasing = false;
       }
     }).start();


### PR DESCRIPTION
When running in Android emulator, the app crashes due to error: 
AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.Camera.setPreviewCallback(android.hardware.Camera$PreviewCallback)' on a null object reference

Checking for the reference makes testing a lot easier