### PR TITLE
Fixing multiple crashes of version 3.0.0 on android torch release

### DIFF
--- a/src/android/nl/xservices/plugins/Flashlight.java
+++ b/src/android/nl/xservices/plugins/Flashlight.java
@@ -88,8 +88,9 @@ public class Flashlight extends CordovaPlugin {
     new Thread(new Runnable() {
       public void run() {
 	if (mCamera != null) {
-          mCamera.setPreviewCallback(null);
           mCamera.stopPreview();
+          mCamera.setPreviewCallback(null);
+          mCamera.unlock();
           mCamera.release();
         }
         releasing = false;


### PR DESCRIPTION
This PR solves many crashes after releasing the camera. The order is first  mCamera.stopPreview(); and later  mCamera.setPreviewCallback(null); 