### PR TITLE
Remove cordova-plugin-compat  and bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-flashlight",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "This plugin allows you switch the Flashlight / Torch of your device on or off.",
   "cordova": {
     "id": "cordova-plugin-flashlight",

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,8 +55,6 @@
     </config-file>
 
     <source-file src="src/android/nl/xservices/plugins/Flashlight.java" target-dir="src/nl/xservices/plugins"/>
-
-    <dependency id="cordova-plugin-compat" version="^1.0.0" />
   </platform>
 
   <!-- wp8 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-flashlight"
-        version="3.2.0">
+        version="3.3.0">
 
   <name>Flashlight</name>
 


### PR DESCRIPTION
In the release notes of cordova-android 6.3.0 (https://cordova.apache.org/announcements/2017/09/27/android-release.html) it's written down that cordova-plugin-compat has to be removed